### PR TITLE
Add support for TPE2 (AlbumArtist) ID3 tag

### DIFF
--- a/ID3TagData.cs
+++ b/ID3TagData.cs
@@ -27,8 +27,10 @@ namespace NAudio.Lame
 		// Experimental:
 		/// <summary>Subtitle (TIT3)</summary>
 		public string Subtitle;
+        /// <summary>AlbumArtist (TPE2)</summary>
+        public string AlbumArtist;
 
-		/// <summary>Album art - PNG, JPG or GIF file content</summary>
-		public byte[] AlbumArt;
+        /// <summary>Album art - PNG, JPG or GIF file content</summary>
+        public byte[] AlbumArt;
 	}
 }

--- a/MP3FileWriter.cs
+++ b/MP3FileWriter.cs
@@ -619,10 +619,14 @@ namespace NAudio.Lame
 			if (!string.IsNullOrEmpty(tag.Track))
 				_lame.ID3SetTrack(tag.Track);
 
-			if (!string.IsNullOrEmpty(tag.Subtitle))
-				_lame.ID3SetFieldValue(string.Format("TIT3={0}", tag.Subtitle));
+            if (!string.IsNullOrEmpty(tag.Subtitle))
+                _lame.ID3SetFieldValue(string.Format("TIT3={0}", tag.Subtitle));
 
-			if (tag.AlbumArt != null && tag.AlbumArt.Length > 0 && tag.AlbumArt.Length < 131072)
+            if (!string.IsNullOrEmpty(tag.AlbumArtist))
+                _lame.ID3SetFieldValue(string.Format("TPE2={0}", tag.AlbumArtist));
+
+
+            if (tag.AlbumArt != null && tag.AlbumArt.Length > 0 && tag.AlbumArt.Length < 131072)
 				_lame.ID3SetAlbumArt(tag.AlbumArt);
 		}
 


### PR DESCRIPTION
As my music is album-based, cataloged using the AlbumArtist (TPE2) ID3 tag, I have added that tag to my fork. It may be of interest more generally.

BTW, Thanks for making this. The library works great and seems bullet-proof!