### PR TITLE
Fix markdown header in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#NAudio.Lame
+# NAudio.Lame
 
 Wrapper for `libmp3lame.dll` to add MP3 encoding support to NAudio.
 


### PR DESCRIPTION
Due to a change in the way GitHub renders markdown, headers are required to have a space after the # sign, otherwise they are not recognized.