### PR TITLE
Expose OutputSampleRate in LAMEConfig

### DIFF
--- a/NAudio.Lame/LameConfig.cs
+++ b/NAudio.Lame/LameConfig.cs
@@ -113,6 +113,8 @@ namespace NAudio.Lame
 				result.SetPreset((int)(_preset ?? LAMEPreset.STANDARD));
 			}
 
+			if (OutputSampleRate != null) result.OutputSampleRate = OutputSampleRate.Value;
+
 			// Scaling
 			if (Scale != null) result.Scale = Scale.Value;
 			if (ScaleLeft != null) result.ScaleLeft = ScaleLeft.Value;

--- a/NAudio.Lame/LameConfig.cs
+++ b/NAudio.Lame/LameConfig.cs
@@ -33,6 +33,8 @@ namespace NAudio.Lame
 					_preset = null;
 			}
 		}
+		/// <summary>Select output sampling frequency. If not specified, LAME will automatically resample the input when using high compression ratios.</summary>
+		public int? OutputSampleRate { get; set; }
 		#endregion
 
 		#region Input settings


### PR DESCRIPTION
Added OutputSampleRate as config parameter, to override LAME's default resample.